### PR TITLE
added dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test.js
 node_modules/
 typings/
 src/devices/template.json
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:8.11.4-alpine
+
+WORKDIR /homeeup
+COPY . /homeeup
+
+RUN yarn install
+
+CMD node /homeeup/bin/homeeup
+
+EXPOSE 2001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.4-alpine
+FROM node:8.11.4-slim
 
 WORKDIR /homeeup
 COPY . /homeeup

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8.11.4-alpine
 WORKDIR /homeeup
 COPY . /homeeup
 
-RUN yarn install
+RUN yarn install --prod
 
 CMD node /homeeup/bin/homeeup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,8 @@ services:
     build: .
     ports:
       - "2001:2001"
+    network_mode: host
     volumes:
       - ~/.homeeup:/root/.homeeup
+    environment:
+      - LOG=info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  app:
+    build: .
+    ports:
+      - "2001:2001"
+    volumes:
+      - ~/.homeeup:/root/.homeeup


### PR DESCRIPTION
network mode "host" is needed to allow connections from host's network. macos does not support this mode at all, so it should only work at linux and win.