### PR TITLE
add dev docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM node:8.11.4-slim
 
-WORKDIR /homeeup
-COPY . /homeeup
-
-RUN yarn install --prod
-
-CMD node /homeeup/bin/homeeup
+RUN npm install -g homeeup
 
 EXPOSE 2001
+
+CMD ["/usr/local/bin/homeeup"]
+

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM node:8.11.4-slim
+
+WORKDIR /homeeup
+COPY . /homeeup
+
+RUN yarn install --prod
+
+CMD node /homeeup/bin/homeeup
+
+EXPOSE 2001

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,11 +1,13 @@
 version: "3"
 services:
-  homeeup:
-    build: .
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
     ports:
       - "2001:2001"
     network_mode: host
     volumes:
       - ~/.homeeup:/root/.homeeup
     environment:
-      - LOG=info
+      - LOG=debug


### PR DESCRIPTION
this enables the user to easy run a homeeup docker container without compiling and stuff

Running the Development Environemnt, where the current src is copied in:
`docker-compose -f docker-compose.dev.yml up`

Running the container on the current stable homeeup available through npm:
`docker-compose -f docker-compose.yml up` or `docker-compose up`

I think this makes it easier for other people to run the software.